### PR TITLE
[NT] Remove ttl, add expireAt for Person schemas, change SearchResponse

### DIFF
--- a/identification.yml
+++ b/identification.yml
@@ -74,11 +74,9 @@ components:
           items:
             type: string
             format: uuid
-        ttl:
-          type: integer
-          description: "The lifespan of the Person's records, seconds. Optional."
-          nullable: true
-          default: null
+        expireAt:
+          type: string
+          description: "Person expiration date."
     PersonToUpdateFields:
       type: object
       description: "Person Request body: name and metadata."

--- a/search.yml
+++ b/search.yml
@@ -28,7 +28,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/definitions/SearchResult"
+                $ref: "#/definitions/SearchPerson"
         400:
           $ref: "./identification.yml#/components/responses/SearchBadParamsException"
 
@@ -118,35 +118,6 @@ definitions:
         description: "Array of Person images. It is returned only with response 200."
         items:
           $ref: "#/definitions/SearchPerson"
-      id:
-        type: string
-        format: uuid
-        description: "Person ID. The list of persons is sorted by decreasing ID value."
-        nullable: true
-      createdAt:
-        type: string
-        description: "Person creation date."
-        nullable: true
-      updatedAt:
-        type: string
-        description: "Person update date."
-        nullable: true
-      groups:
-        type: array
-        description: "List of groups this person belongs to."
-        nullable: true
-        items:
-          type: string
-          format: uuid
-      name:
-        type: string
-        description: "Person's name."
-        nullable: true
-      metadata:
-        type: object
-        additionalProperties: true
-        description: "A free-form object containing person's extended attributes. Available when a person is being created"
-
   SearchPerson:
     allOf:
       - $ref: "./identification.yml#/components/schemas/Person"


### PR DESCRIPTION
There are no new features, just fix some inaccuracies. Remove `ttl`, add `expireAt` for Person schemas. Replace response for `/search`.

### Models
Before:
<img width="693" alt="image" src="https://github.com/user-attachments/assets/dec0416d-06b0-4f97-9e33-583b31606453" />

After:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/c244f28b-da2b-4480-b50e-0f7584438c66" />

### TTL -> expireAt
Before:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/bb0f894c-a859-448b-b4ae-57519db98ccc" />

After:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/f09428ab-ade6-43f6-8a86-2d42aa060a44" />
